### PR TITLE
Add some permissions to allow the workflow to create a GHCR package

### DIFF
--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -15,6 +15,12 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
     steps:
       - name: Parse image tag
         id: parse_image_tag


### PR DESCRIPTION
fixes the container build 🤞🏻 